### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mk-appendix.py
+++ b/mk-appendix.py
@@ -30,7 +30,7 @@ for l in sys.stdin:
             m = re.match('%%(#+|!) (.*)$', l)
             if m is not None:
                 if m.group(1) != '!':
-                    print "%s %s"%(m.group(1), m.group(2))
+                    print "{0!s} {1!s}".format(m.group(1), m.group(2))
                 print_syntax(APPENDICES[m.group(2)])
                 del APPENDICES[m.group(2)]
                 print


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:tls13-spec?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:tls13-spec?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
